### PR TITLE
Don't add jacoco tasks for ignored build variants

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/Generation.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/Generation.groovy
@@ -144,8 +144,7 @@ class Generation implements Plugin<Project> {
 
                 additionalSourceDirs = subProject.files(coverageSourceDirs)
                 sourceDirectories = subProject.files(coverageSourceDirs)
-                executionData =
-                        subProject.files("${subProject.buildDir}/jacoco/${testTaskName}.exec")
+                executionData = subProject.files("${subProject.buildDir}/jacoco/${testTaskName}.exec")
             }
 
             subProject.check.dependsOn "${taskName}"

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/ProjectHelper.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/ProjectHelper.groovy
@@ -42,7 +42,7 @@ final class ProjectHelper {
                 androidMock.metaClass.getApplicationVariants = { appVariants }
                 androidMock.metaClass.testOptions = null
                 project.metaClass.android = androidMock
-                // fake all with each
+                // mock .all{ } function from android gradle lib with standard groovy .each{ }
                 project.android.applicationVariants.metaClass.all = { delegate.each(it) }
                 break
             case ProjectType.ANDROID_LIBRARY:
@@ -63,7 +63,7 @@ final class ProjectHelper {
                 androidMock.metaClass.getLibraryVariants = { appVariants }
                 androidMock.metaClass.testOptions = null
                 project.metaClass.android = androidMock
-                // fake all with each
+                // mock .all{ } function from android gradle lib with standard groovy .each{ }
                 project.android.libraryVariants.metaClass.all = { delegate.each(it) }
                 break
         }
@@ -99,10 +99,12 @@ final class ProjectHelper {
         switch (projectType) {
             case ProjectType.ANDROID_APPLICATION:
                 project.android.metaClass.applicationVariants = variants
+                // mock .all{ } function from android gradle lib with standard groovy .each{ }
                 project.android.applicationVariants.metaClass.all = { delegate.each(it) }
                 break
             case ProjectType.ANDROID_LIBRARY:
                 project.android.metaClass.libraryVariants = variants
+                // mock .all{ } function from android gradle lib with standard groovy .each{ }
                 project.android.libraryVariants.metaClass.all = { delegate.each(it) }
                 break
         }


### PR DESCRIPTION
Fixes #67

The new implementation uses `android.libraryVariants` or `android.applicationVariants` instead of iterating manually over buildTypes and flavors. The bug is fixed because ignored variants are not included.