### PR TITLE
Support popular JVM languages

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -68,7 +68,11 @@ class GenerationPlugin implements Plugin<Project> {
             )
 
             final def coverageSourceDirs = [
-                    'src/main/java',
+                'src/main/clojure',
+                'src/main/groovy',
+                'src/main/java',
+                'src/main/kotlin',
+                'src/main/scala'
             ]
 
             additionalSourceDirs = subProject.files(coverageSourceDirs)
@@ -134,7 +138,11 @@ class GenerationPlugin implements Plugin<Project> {
                 )
 
                 final def coverageSourceDirs = [
+                        "src/main/clojure",
+                        "src/main/groovy",
                         "src/main/java",
+                        "src/main/kotlin",
+                        "src/main/scala",
                         "src/$buildTypeName/java"
                 ]
 

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -143,11 +143,19 @@ class GenerationPlugin implements Plugin<Project> {
                         "src/main/java",
                         "src/main/kotlin",
                         "src/main/scala",
-                        "src/$buildTypeName/java"
+                        "src/$buildTypeName/clojure",
+                        "src/$buildTypeName/groovy",
+                        "src/$buildTypeName/java",
+                        "src/$buildTypeName/kotlin",
+                        "src/$buildTypeName/scala"
                 ]
 
                 if (productFlavorName) {
+                    coverageSourceDirs.add("src/$productFlavorName/clojure")
+                    coverageSourceDirs.add("src/$productFlavorName/groovy")
                     coverageSourceDirs.add("src/$productFlavorName/java")
+                    coverageSourceDirs.add("src/$productFlavorName/kotlin")
+                    coverageSourceDirs.add("src/$productFlavorName/scala")
                 }
 
                 additionalSourceDirs = subProject.files(coverageSourceDirs)

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -138,12 +138,10 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/test${flavor.capitalize()}${buildType.capitalize()}UnitTest.exec")
 
-            assert additionalSourceDirs.size() == 3
             assert additionalSourceDirs.contains(project.file('src/main/java'))
             assert additionalSourceDirs.contains(project.file("src/${buildType}/java"))
             assert additionalSourceDirs.contains(project.file("src/${flavor}/java"))
 
-            assert sourceDirectories.size() == 3
             assert sourceDirectories.contains(project.file('src/main/java'))
             assert sourceDirectories.contains(project.file("src/${buildType}/java"))
             assert sourceDirectories.contains(project.file("src/${flavor}/java"))
@@ -175,11 +173,9 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/testDebugUnitTest.exec")
 
-            assert additionalSourceDirs.size() == 2
             assert additionalSourceDirs.contains(project.file('src/main/java'))
             assert additionalSourceDirs.contains(project.file('src/debug/java'))
 
-            assert sourceDirectories.size() == 2
             assert sourceDirectories.contains(project.file('src/main/java'))
             assert sourceDirectories.contains(project.file('src/debug/java'))
 
@@ -204,11 +200,9 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/testReleaseUnitTest.exec")
 
-            assert additionalSourceDirs.size() == 2
             assert additionalSourceDirs.contains(project.file('src/main/java'))
             assert additionalSourceDirs.contains(project.file('src/release/java'))
 
-            assert sourceDirectories.size() == 2
             assert sourceDirectories.contains(project.file('src/main/java'))
             assert sourceDirectories.contains(project.file('src/release/java'))
 
@@ -239,10 +233,8 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/test.exec")
 
-            assert additionalSourceDirs.size() == 1
             assert additionalSourceDirs.contains(project.file('src/main/java'))
 
-            assert sourceDirectories.size() == 1
             assert sourceDirectories.contains(project.file('src/main/java'))
 
             assert classDirectories.dir == project.file('build/classes/main/')

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -9,7 +9,9 @@ import org.junit.Test
 import static com.vanniktech.android.junit.jacoco.ProjectHelper.ProjectType.*
 
 public class GenerationTest {
-    @Test
+  def LANGUAGES = ["clojure", "groovy", "java", "kotlin", "scala"]
+
+  @Test
     public void addJacocoAndroidAppWithFlavors() {
         def androidAppProject = ProjectHelper.prepare(ANDROID_APPLICATION).withRedBlueFlavors().get()
 
@@ -138,13 +140,19 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/test${flavor.capitalize()}${buildType.capitalize()}UnitTest.exec")
 
-            assert additionalSourceDirs.contains(project.file('src/main/java'))
-            assert additionalSourceDirs.contains(project.file("src/${buildType}/java"))
-            assert additionalSourceDirs.contains(project.file("src/${flavor}/java"))
+            assert additionalSourceDirs.size() == 15
+            LANGUAGES.every {
+              assert additionalSourceDirs.contains(project.file("src/main/$it"))
+              assert additionalSourceDirs.contains(project.file("src/${buildType}/$it"))
+              assert additionalSourceDirs.contains(project.file("src/${flavor}/$it"))
+            }
 
-            assert sourceDirectories.contains(project.file('src/main/java'))
-            assert sourceDirectories.contains(project.file("src/${buildType}/java"))
-            assert sourceDirectories.contains(project.file("src/${flavor}/java"))
+            assert sourceDirectories.size() == 15
+            LANGUAGES.every {
+              assert sourceDirectories.contains(project.file("src/main/$it"))
+              assert sourceDirectories.contains(project.file("src/${buildType}/$it"))
+              assert sourceDirectories.contains(project.file("src/${flavor}/$it"))
+            }
 
             assert reports.xml.enabled
             assert reports.xml.destination.toString() == project.buildDir.absolutePath + "/reports/jacoco/${flavor}${buildType.capitalize()}/jacoco.xml"
@@ -173,11 +181,17 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/testDebugUnitTest.exec")
 
-            assert additionalSourceDirs.contains(project.file('src/main/java'))
-            assert additionalSourceDirs.contains(project.file('src/debug/java'))
+            assert additionalSourceDirs.size() == 10
+            LANGUAGES.every {
+              assert additionalSourceDirs.contains(project.file("src/main/$it"))
+              assert additionalSourceDirs.contains(project.file("src/debug/$it"))
+            }
 
-            assert sourceDirectories.contains(project.file('src/main/java'))
-            assert sourceDirectories.contains(project.file('src/debug/java'))
+            assert sourceDirectories.size() == 10
+            LANGUAGES.every {
+             assert sourceDirectories.contains(project.file("src/main/$it"))
+             assert sourceDirectories.contains(project.file("src/debug/$it"))
+            }
 
             assert reports.xml.enabled
             assert reports.xml.destination.toString() == project.buildDir.absolutePath + '/reports/jacoco/debug/jacoco.xml'
@@ -200,11 +214,17 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/testReleaseUnitTest.exec")
 
-            assert additionalSourceDirs.contains(project.file('src/main/java'))
-            assert additionalSourceDirs.contains(project.file('src/release/java'))
+            assert additionalSourceDirs.size() == 10
+            LANGUAGES.every {
+              assert additionalSourceDirs.contains(project.file("src/main/$it"))
+              assert additionalSourceDirs.contains(project.file("src/release/$it"))
+            }
 
-            assert sourceDirectories.contains(project.file('src/main/java'))
-            assert sourceDirectories.contains(project.file('src/release/java'))
+            assert sourceDirectories.size() == 10
+            LANGUAGES.every {
+              assert sourceDirectories.contains(project.file("src/main/$it"))
+              assert sourceDirectories.contains(project.file("src/release/$it"))
+            }
 
             assert reports.xml.enabled
             assert reports.xml.destination.toString() == project.buildDir.absolutePath + '/reports/jacoco/release/jacoco.xml'
@@ -233,9 +253,15 @@ public class GenerationTest {
 
             assert executionData.singleFile == project.file("${project.buildDir}/jacoco/test.exec")
 
-            assert additionalSourceDirs.contains(project.file('src/main/java'))
+            assert additionalSourceDirs.size() == 5
+            LANGUAGES.every {
+              assert additionalSourceDirs.contains(project.file("src/main/$it"))
+            }
 
-            assert sourceDirectories.contains(project.file('src/main/java'))
+            assert sourceDirectories.size() == 5
+            LANGUAGES.every {
+              assert sourceDirectories.contains(project.file("src/main/$it"))
+            }
 
             assert classDirectories.dir == project.file('build/classes/main/')
 


### PR DESCRIPTION
@vanniktech 
Closes #74

Based on popular JVM languages: https://www.slant.co/topics/397/~best-languages-that-run-on-the-jvm

Officially supported by Android: Java + Android

Other popular languages supported by Gradle plugins for Android:
https://github.com/JetBrains/kotlin/tree/master/libraries/tools/kotlin-gradle-plugin
https://github.com/groovy/groovy-android-gradle-plugin
https://github.com/scala-android/sbt-android
https://github.com/clojure-android/android-clojure-plugin