### PR TITLE
Revert "Remove codecov and use coveralls"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ groovy:
 jdk:
     - oraclejdk8
 
+before_install:
+    - pip install --user codecov
+
 install: true
 
-script: ./gradlew clean build coveralls
+script: ./gradlew clean build
 
 after_success:
     - .buildscript/deploy_snapshot.sh
+    - codecov
 
 env:
     global:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gradle-android-junit-jacoco-plugin
 
 [![Build Status](https://travis-ci.org/vanniktech/gradle-android-junit-jacoco-plugin.svg?branch=master)](https://travis-ci.org/vanniktech/gradle-android-junit-jacoco-plugin?branch=master)
-[![Coveralls Code Coverage](https://img.shields.io/coveralls/vanniktech/gradle-android-junit-jacoco-plugin/master.svg?label=Code%20Coverage)](https://coveralls.io/github/vanniktech/gradle-android-junit-jacoco-plugin?branch=master)
+[![Codecov](https://codecov.io/github/vanniktech/gradle-android-junit-jacoco-plugin/coverage.svg?branch=master)](https://codecov.io/github/vanniktech/gradle-android-junit-jacoco-plugin?branch=master)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 ![Java 7 required](https://img.shields.io/badge/java-7-brightgreen.svg)
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
     dependencies {
         classpath 'com.gradle.publish:plugin-publish-plugin:0.9.1'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.1'
         classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.7.0'
     }
 }
@@ -17,7 +16,6 @@ apply plugin: 'java'
 apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'com.vanniktech.android.junit.jacoco'
-apply plugin: 'com.github.kt3k.coveralls'
 
 repositories {
     jcenter()
@@ -76,10 +74,6 @@ artifacts {
     archives groovydocJar
     archives javadocJar
     archives sourcesJar
-}
-
-coveralls {
-  jacocoReportPath = "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
 }
 
 apply from: file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
Reverts vanniktech/gradle-android-junit-jacoco-plugin#73

Too lazy to change coveralls in all of my projects and I prefer having to maintain only one system. Thanks for all the effort @jaredsburrows 