### PR TITLE
Update plugin-publish-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.1'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.9'
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
         classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.9.0'
     }


### PR DESCRIPTION
Hiya, I was doing a quick scan of the gradle plugin portal and noticed you were using an old version of the plugin-publish-plugin.

There was a bug in versions prior to 0.9.7, where artifacts would silently not be pushed into the repo, which means the latest version of your plugin will not work properly when people apply it to their build.

Upgrading the plugin will fix this, but this will require pushing a new version of your plugin :-/

Thanks (and sorry about that)