### PR TITLE
Allow ignoring the module path and name

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -301,6 +301,19 @@ class GenerationPlugin implements Plugin<Project> {
     }
 
     private static boolean shouldIgnore(final Project project, final JunitJacocoExtension extension) {
-        return extension.ignoreProjects?.contains(project.name) || extension.ignoreProjects?.contains(project.path)
+        boolean result = extension.ignoreProjects?.contains(project.name) || extension.ignoreProjects?.contains(project.path)
+        if (result) {
+            // regex could be slower
+            return true
+        }
+
+        extension.ignoreProjects?.each {
+            if (project.name.find(it) || project.path.find(it)) {
+                result = true
+                return true
+            }
+        }
+
+        return result
     }
 }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -301,19 +301,19 @@ class GenerationPlugin implements Plugin<Project> {
     }
 
     private static boolean shouldIgnore(final Project project, final JunitJacocoExtension extension) {
-        boolean result = extension.ignoreProjects?.contains(project.name) || extension.ignoreProjects?.contains(project.path)
-        if (result) {
+        if (extension.ignoreProjects?.contains(project.name) || extension.ignoreProjects?.contains(project.path)) {
             // regex could be slower
             return true
         }
 
-        extension.ignoreProjects?.each {
-            if (project.name.find(it) || project.path.find(it)) {
-                result = true
-                return true
+        if (extension.ignoreProjects != null) {
+            for (String ignoredProject : extension.ignoreProjects) {
+                if (project.name.find(ignoredProject) || project.path.find(ignoredProject)) {
+                    return true
+                }
             }
         }
 
-        return result
+        return false
     }
 }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -301,6 +301,6 @@ class GenerationPlugin implements Plugin<Project> {
     }
 
     private static boolean shouldIgnore(final Project project, final JunitJacocoExtension extension) {
-        return extension.ignoreProjects?.contains(project.name)
+        return extension.ignoreProjects?.contains(project.name) || extension.ignoreProjects?.contains(project.path)
     }
 }

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -90,6 +90,22 @@ public class GenerationTest {
     }
 
     @Test
+    public void ignoreProjectsPath() {
+        final def extension = new JunitJacocoExtension()
+        final def projects = [
+                ProjectHelper.prepare(ANDROID_APPLICATION).get(),
+                ProjectHelper.prepare(ANDROID_LIBRARY).get(),
+                ProjectHelper.prepare(JAVA).get()] as Project[]
+
+        for (final def project : projects) {
+            extension.ignoreProjects = [project.path]
+
+            assert !GenerationPlugin.addJacoco(project, extension)
+            assert !project.plugins.hasPlugin(JacocoPlugin)
+        }
+    }
+
+    @Test
     public void androidAppBuildExecutesJacocoTask() {
         def androidAppProject = ProjectHelper.prepare(ANDROID_APPLICATION).get()
 

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -106,6 +106,52 @@ public class GenerationTest {
     }
 
     @Test
+    public void ignoreProjectsRegexPath() {
+        final def extension = new JunitJacocoExtension()
+        final def projects = [
+                ProjectHelper.prepare(ANDROID_APPLICATION).get(),
+                ProjectHelper.prepare(ANDROID_LIBRARY).get(),
+                ProjectHelper.prepare(JAVA).get()] as Project[]
+
+        for (final def project : projects) {
+            extension.ignoreProjects = [".*"]
+
+            assert !GenerationPlugin.addJacoco(project, extension)
+            assert !project.plugins.hasPlugin(JacocoPlugin)
+        }
+    }
+
+    @Test
+    public void ignoreProjectsRegexName() {
+        final def extension = new JunitJacocoExtension()
+        final def projects = [
+                ProjectHelper.prepare(ANDROID_APPLICATION).get(),
+                ProjectHelper.prepare(ANDROID_LIBRARY).get()] as Project[]
+
+        for (final def project : projects) {
+            extension.ignoreProjects = ["android*"]
+
+            assert !GenerationPlugin.addJacoco(project, extension)
+            assert !project.plugins.hasPlugin(JacocoPlugin)
+        }
+    }
+
+    @Test
+    public void ignoreProjectsWrongRegexName() {
+        final def extension = new JunitJacocoExtension()
+        final def projects = [
+                ProjectHelper.prepare(ANDROID_APPLICATION).get(),
+                ProjectHelper.prepare(ANDROID_LIBRARY).get()] as Project[]
+
+        for (final def project : projects) {
+            extension.ignoreProjects = ["androidFFF*"]
+
+            assert GenerationPlugin.addJacoco(project, extension)
+            assert project.plugins.hasPlugin(JacocoPlugin)
+        }
+    }
+
+    @Test
     public void androidAppBuildExecutesJacocoTask() {
         def androidAppProject = ProjectHelper.prepare(ANDROID_APPLICATION).get()
 


### PR DESCRIPTION
Imagine you have a setup like `:libs:someLib1:library` and `:libs:someLib2:library`, then you need to use the path and not the name.