### PR TITLE
Use Jacoco 0.8.2 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Those are all available configurations - shown with default values and their typ
 
 ```groovy
 junitJacoco {
-  jacocoVersion = '0.7.2.201409121644' // type String
+  jacocoVersion = '0.8.2' // type String
   ignoreProjects = [] // type String array
   excludes // type String List
   includeNoLocationClasses = false // type boolean

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -9,7 +9,7 @@ class JunitJacocoExtension {
      * define the version of jacoco which should be used
      * @since 0.3.0
      */
-    String jacocoVersion = '0.7.2.201409121644'
+    String jacocoVersion = '0.8.2'
 
     /**
      * subprojects that should be ignored

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -169,7 +169,7 @@ class GenerationTest {
     private void assertJacocoAndroidWithFlavors(final Project project) {
         assert project.plugins.hasPlugin(JacocoPlugin)
 
-        assert project.jacoco.toolVersion == '0.7.2.201409121644'
+        assert project.jacoco.toolVersion == '0.8.2'
 
         assertTask(project, 'red', 'debug')
         assertTask(project, 'red', 'release')
@@ -220,7 +220,7 @@ class GenerationTest {
     private void assertJacocoAndroidWithoutFlavors(final Project project) {
         assert project.plugins.hasPlugin(JacocoPlugin)
 
-        assert project.jacoco.toolVersion == '0.7.2.201409121644'
+        assert project.jacoco.toolVersion == '0.8.2'
 
         final def debugTask = project.tasks.findByName('jacocoTestReportDebug')
 
@@ -298,7 +298,7 @@ class GenerationTest {
     private void assertJacocoJava(final Project project) {
         assert project.plugins.hasPlugin(JacocoPlugin)
 
-        assert project.jacoco.toolVersion == '0.7.2.201409121644'
+        assert project.jacoco.toolVersion == '0.8.2'
 
         final def task = project.tasks.findByName('jacocoTestReport')
 

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
@@ -6,7 +6,7 @@ class JunitJacocoExtensionTest {
   @Test void defaults() {
     def extension = new JunitJacocoExtension()
 
-    assert extension.jacocoVersion == '0.7.2.201409121644'
+    assert extension.jacocoVersion == '0.8.2'
     assert extension.ignoreProjects.size() == 0
     assert extension.excludes == null
     assert !extension.includeNoLocationClasses


### PR DESCRIPTION
I don't see why the plugin should use a 4 year old Jacoco version by default. The latest plugin works better with Kotlin and contains many other good fixes. Good default values are important in my opinion.