### PR TITLE
Integrate instrumentation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,27 @@ Gradle plugin that generates Jacoco reports from a Gradle Project. Android Appli
 
 ### Android project
 
+*JVM Unit-Tests*
 - Task `jacocoTestReport<Flavor><BuildType>`
   - Executes the `test<Flavor><BuildType>UnitTest` task before
   - Gets executed when the `check` task is executed
   - Generated Jacoco reports can be found under `build/reports/jacoco/<Flavor>/<BuildType>`.
+
+*Instrumentation tests*
+- Task `combinedTestReport<Flavor><BuildType>`
+  - Executes the `test<Flavor><BuildType>UnitTest` and `create<Flavor><BuildType>CoverageReports` tasks before (JVM and instrumentation tests)
+  - Gets executed when the `check` task is executed
+  - Generated Jacoco reports can be found under `build/reports/jacocoCombined/<Flavor>/<BuildType>`.
+Note that this task is only generated, if you set `testCoverageEnabled = true` for your [build type](https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.BuildType.html#com.android.build.gradle.internal.dsl.BuildType:testCoverageEnabled), e.g.
+```groovy
+android {
+    buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
+    }
+}
+```
 
 Where `<BuildType>` is usually `debug` & `release` unless additional build types where specified.
 `<Flavor>` is optional and will be ignored if not specified.
@@ -75,6 +92,8 @@ junitJacoco {
   ignoreProjects = [] // type String array
   excludes // type String List
   includeNoLocationClasses = false // type boolean
+  configureInstrumentationCoverage = true // type boolean
+  includeInstrumentationCoverageInMergedReport = false// type boolean
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ junitJacoco {
   ignoreProjects = [] // type String array
   excludes // type String List
   includeNoLocationClasses = false // type boolean
-  includeInstrumentationCoverageInMergedReport = false// type boolean
+  includeInstrumentationCoverageInMergedReport = false // type boolean
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Gradle plugin that generates Jacoco reports from a Gradle Project. Android Appli
   - Gets executed when the `check` task is executed
   - Generated Jacoco reports can be found under `build/reports/jacoco/<Flavor>/<BuildType>`.
 
-*Instrumentation tests*
+*Instrumented tests*
 - Task `combinedTestReport<Flavor><BuildType>`
-  - Executes the `test<Flavor><BuildType>UnitTest` and `create<Flavor><BuildType>CoverageReports` tasks before (JVM and instrumentation tests)
+  - Executes the `test<Flavor><BuildType>UnitTest` and `create<Flavor><BuildType>CoverageReports` tasks before (JVM and instrumented tests)
   - Gets executed when the `check` task is executed
   - Generated Jacoco reports can be found under `build/reports/jacocoCombined/<Flavor>/<BuildType>`.
 Note that this task is only generated, if you set `testCoverageEnabled = true` for your [build type](https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.BuildType.html#com.android.build.gradle.internal.dsl.BuildType:testCoverageEnabled), e.g.
 ```groovy
 android {
-    buildTypes {
-        debug {
-            testCoverageEnabled true
-        }
+  buildTypes {
+    debug {
+      testCoverageEnabled true
     }
+  }
 }
 ```
 
@@ -92,7 +92,6 @@ junitJacoco {
   ignoreProjects = [] // type String array
   excludes // type String List
   includeNoLocationClasses = false // type boolean
-  configureInstrumentationCoverage = true // type boolean
   includeInstrumentationCoverageInMergedReport = false// type boolean
 }
 ```

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -115,9 +115,7 @@ class GenerationPlugin implements Plugin<Project> {
             it.jacoco.includeNoLocationClasses = extension.includeNoLocationClasses
         }
 
-        if (extension.configureInstrumentationCoverage) {
-            subProject.android.jacoco.version = extension.jacocoVersion
-        }
+        subProject.android.jacoco.version = extension.jacocoVersion
 
         Collection<BaseVariant> variants = []
         if (isAndroidApplication(subProject)) {
@@ -153,7 +151,7 @@ class GenerationPlugin implements Plugin<Project> {
             addJacocoTask(false, subProject, extension, mergeTask, mergedReportTask, jvmTaskName,
                 jvmTestTaskName, instrumentationTestTaskName, sourceName, sourcePath, productFlavorName, buildTypeName)
 
-            if (extension.configureInstrumentationCoverage && buildType.testCoverageEnabled) {
+            if (buildType.testCoverageEnabled) {
                 addJacocoTask(true, subProject, extension, mergeTask, mergedReportTask, combinedTaskName,
                     jvmTestTaskName, instrumentationTestTaskName, sourceName, sourcePath, productFlavorName, buildTypeName)
             }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -30,14 +30,6 @@ class JunitJacocoExtension {
     boolean includeNoLocationClasses
 
     /**
-     * Whether or not to use this plugin for configuring the Jacoco version and creating
-     * a task to combine the coverage reports for instrumentation and unit tests. The default
-     * value is true.
-     * @since 0.13.0
-     */
-    boolean configureInstrumentationCoverage = true
-
-    /**
      * Whether or not to include instrumentation coverage in the final global merged report.
      * Note that this will run all instrumentation tests when true.
      * @since 0.13.0

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -28,4 +28,19 @@ class JunitJacocoExtension {
      * @since 0.6.0
      */
     boolean includeNoLocationClasses
+
+    /**
+     * Whether or not to use this plugin for configuring the Jacoco version and creating
+     * a task to combine the coverage reports for instrumentation and unit tests. The default
+     * value is true.
+     * @since 0.13.0
+     */
+    boolean configureInstrumentationCoverage = true
+
+    /**
+     * Whether or not to include instrumentation coverage in the final global merged report.
+     * Note that this will run all instrumentation tests when true.
+     * @since 0.13.0
+     */
+    boolean includeInstrumentationCoverageInMergedReport = false
 }

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -106,7 +106,9 @@ class GenerationTest {
         GenerationPlugin.addJacoco(javaProject, extension)
 
         assert androidAppProject.jacoco.toolVersion == extension.jacocoVersion
+        assert androidAppProject.android.jacoco.version == extension.jacocoVersion
         assert androidLibraryProject.jacoco.toolVersion == extension.jacocoVersion
+        assert androidLibraryProject.android.jacoco.version == extension.jacocoVersion
         assert javaProject.jacoco.toolVersion == extension.jacocoVersion
     }
 

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -53,30 +53,27 @@ class GenerationTest {
 
     @Test void addJacocoAndroidAppWithoutInstrumentationCoverage() {
         def androidAppProject = ProjectHelper.prepare(ANDROID_APPLICATION).get()
+        androidAppProject.android.buildTypes.each { it.testCoverageEnabled = false }
 
-        def extension = new JunitJacocoExtension()
-        extension.configureInstrumentationCoverage = false
-        GenerationPlugin.addJacoco(androidAppProject, extension)
+        GenerationPlugin.addJacoco(androidAppProject, new JunitJacocoExtension())
 
         assertJacocoAndroidWithoutFlavors(androidAppProject, false)
     }
 
     @Test void addJacocoAndroidLibraryWithoutInstrumentationCoverage() {
         def androidLibraryProject = ProjectHelper.prepare(ANDROID_LIBRARY).get()
+        androidLibraryProject.android.buildTypes.each { it.testCoverageEnabled = false }
 
-        def extension = new JunitJacocoExtension()
-        extension.configureInstrumentationCoverage = false
-        GenerationPlugin.addJacoco(androidLibraryProject, extension)
+        GenerationPlugin.addJacoco(androidLibraryProject, new JunitJacocoExtension())
 
         assertJacocoAndroidWithoutFlavors(androidLibraryProject, false)
     }
 
     @Test void addJacocoAndroidFeatureWithoutInstrumentationCoverage() {
         def androidLibraryProject = ProjectHelper.prepare(ANDROID_FEATURE).get()
+        androidLibraryProject.android.buildTypes.each { it.testCoverageEnabled = false }
 
-        def extension = new JunitJacocoExtension()
-        extension.configureInstrumentationCoverage = false
-        GenerationPlugin.addJacoco(androidLibraryProject, extension)
+        GenerationPlugin.addJacoco(androidLibraryProject, new JunitJacocoExtension())
 
         assertJacocoAndroidWithoutFlavors(androidLibraryProject, false)
     }

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
@@ -10,7 +10,6 @@ class JunitJacocoExtensionTest {
     assert extension.ignoreProjects.size() == 0
     assert extension.excludes == null
     assert !extension.includeNoLocationClasses
-    assert extension.configureInstrumentationCoverage
     assert !extension.includeInstrumentationCoverageInMergedReport
   }
 }

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
@@ -10,5 +10,7 @@ class JunitJacocoExtensionTest {
     assert extension.ignoreProjects.size() == 0
     assert extension.excludes == null
     assert !extension.includeNoLocationClasses
+    assert extension.configureInstrumentationCoverage
+    assert !extension.includeInstrumentationCoverageInMergedReport
   }
 }

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/ProjectHelper.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/ProjectHelper.groovy
@@ -9,6 +9,7 @@ import com.android.builder.model.BuildType
 import groovy.mock.interceptor.MockFor
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
+
 /** Provides projects for testing */
 final class ProjectHelper {
     static ProjectHelper prepare(ProjectType projectType) {


### PR DESCRIPTION
Generate a task that runs unit tests and instrumentation tests for a module and combines their execution data in a single report. Add the option to include instrumentation tests in the global merged report.