### PR TITLE
Adding includes Extension to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Those are all available configurations - shown with default values and their typ
 junitJacoco {
   jacocoVersion = '0.8.2' // type String
   ignoreProjects = [] // type String array
-  excludes // type String List
+  includes = [] // type String List
+  excludes = [] // type String List
   includeNoLocationClasses = false // type boolean
   includeInstrumentationCoverageInMergedReport = false // type boolean
 }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -68,7 +68,7 @@ class GenerationPlugin implements Plugin<Project> {
 
             classDirectories = subProject.fileTree(
                     dir: subProject.buildDir,
-                    includes: ['**/classes/**/main/**'],
+                    includes: getIncludes(extension),
                     excludes: getExcludes(extension)
             )
 
@@ -309,6 +309,10 @@ class GenerationPlugin implements Plugin<Project> {
         }
 
         return [mergeTask, mergedReportTask]
+    }
+
+    static List<String> getIncludes(final JunitJacocoExtension extension) {
+        extension.includes == null ? ['**/classes/**/main/**'] : extension.includes
     }
 
     static List<String> getExcludes(final JunitJacocoExtension extension) {

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -18,7 +18,13 @@ class JunitJacocoExtension {
     String[] ignoreProjects = []
 
     /**
-     * Patterns of files that should be ignored
+     * Patterns of class files that should be included
+     * @since 0.14.0
+     */
+    List<String> includes = null
+
+    /**
+     * Patterns of class files that should be ignored
      * @since 0.5.0
      */
     List<String> excludes = null

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -496,6 +496,23 @@ class GenerationTest {
         return false
     }
 
+    @Test void getIncludesDefault() {
+        final def includes = GenerationPlugin.getIncludes(new JunitJacocoExtension())
+
+        assert includes.size == 1
+        assert includes.contains('**/classes/**/main/**')
+    }
+
+    @Test void getIncludesCustom() {
+      final def extension = new JunitJacocoExtension()
+      extension.includes = new ArrayList<>()
+      extension.includes.add("**/toto/**")
+
+      final def includes = GenerationPlugin.getIncludes(extension)
+
+      assert includes == extension.includes
+    }
+
     @Test void getExcludesDefault() {
         final def excludes = GenerationPlugin.getExcludes(new JunitJacocoExtension())
 


### PR DESCRIPTION
If your Android project has local dependencies (example: io.realm), those will appear into the merged report since the class files are included (the default inclusion rule is '**/classes/**/main/**').

The way the Jenkins plugin handles this is by providing a way to customize the list of included classes (example: com.ogoutay.test), to include only your application classes in the jacoco merged reports.

Exclusion could have been a solution too, but it's less developer friendly, since you would need to add a new exclusion every time you add a new dependency to your project.

This PR:
- Add an "includes" extension in JunitJacocoExtension.groovy
- Handles "includes" the same way "excludes" are handled in GenerationTest.groovy
- Updated unit tests (and passing)
- Updated README

Let me know if you have any suggestion or want to change anything!

Thank you :)

<img width="774" alt="screen shot 2018-12-06 at 2 27 49 pm" src="https://user-images.githubusercontent.com/1358863/49615663-21444180-f963-11e8-8822-1e75135659a7.png">
