### PR TITLE
Cope with new Android DSL to configure includeNoLocationClasses

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -3,6 +3,7 @@ package com.vanniktech.android.junit.jacoco
 import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.tasks.JacocoMerge
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
@@ -109,6 +110,10 @@ class GenerationPlugin implements Plugin<Project> {
             it.jacoco.includeNoLocationClasses = extension.includeNoLocationClasses
         }
 
+        subProject.tasks.withType(Test) {
+            it.jacoco.includeNoLocationClasses = extension.includeNoLocationClasses
+        }
+        
         subProject.android.jacoco.version = extension.jacocoVersion
 
         Collection<BaseVariant> variants = []

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -106,14 +106,10 @@ class GenerationPlugin implements Plugin<Project> {
             toolVersion extension.jacocoVersion
         }
 
-        subProject.android.testOptions?.unitTests?.all {
-            it.jacoco.includeNoLocationClasses = extension.includeNoLocationClasses
-        }
-
         subProject.tasks.withType(Test) {
             it.jacoco.includeNoLocationClasses = extension.includeNoLocationClasses
         }
-        
+
         subProject.android.jacoco.version = extension.jacocoVersion
 
         Collection<BaseVariant> variants = []


### PR DESCRIPTION
Small fix due to Android DSL 3.3.0 update