### PR TITLE
Fix "Could not get unknown property 'libraryVariants'" for dynamic-feature modules

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -113,9 +113,9 @@ class GenerationPlugin implements Plugin<Project> {
         subProject.android.jacoco.version = extension.jacocoVersion
 
         Collection<BaseVariant> variants = []
-        if (isAndroidApplication(subProject)) {
+        if (isAndroidApplication(subProject) || isAndroidDynamicFeature(subProject)) {
             variants = subProject.android.applicationVariants
-        } else if (isAndroidLibrary(subProject) || isAndroidFeature(subProject) || isAndroidDynamicFeature(subProject)) {
+        } else if (isAndroidLibrary(subProject) || isAndroidFeature(subProject)) {
             // FeatureExtension extends LibraryExtension
             variants = subProject.android.libraryVariants
         } else {

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/ProjectHelper.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/ProjectHelper.groovy
@@ -39,6 +39,7 @@ final class ProjectHelper {
                 break
             case ProjectType.ANDROID_APPLICATION:
             case ProjectType.ANDROID_KOTLIN_APPLICATION:
+            case ProjectType.ANDROID_DYNAMIC_FEATURE:
                 project = builder.withName('android app').build()
                 def androidMock = new MockFor(AppExtension)
                 def buildTypesMock = ["debug", "release"].collect { bt ->
@@ -63,7 +64,6 @@ final class ProjectHelper {
                 break
             case ProjectType.ANDROID_LIBRARY:
             case ProjectType.ANDROID_FEATURE:
-            case ProjectType.ANDROID_DYNAMIC_FEATURE:
             case ProjectType.ANDROID_KOTLIN_MULTIPLATFORM:
                 project = builder.withName('android library').build()
                 def androidMock = new MockFor(LibraryExtension)


### PR DESCRIPTION
It looks like my prev dynamic-feature PR https://github.com/vanniktech/gradle-android-junit-jacoco-plugin/pull/158 requires some polishing.

After applying it to a project I got the error:
```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':feature_album'.
> Could not get unknown property 'libraryVariants' for object of type com.android.build.gradle.AppExtension.
```

`com.android.dynamic-feature` modules behaves differently than old `com.adndroid.featute` and do not have `libraryVariants` properly (it is `AppExtension`, not a `FeatureExtension`). Looking at [AppExtension docs](https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.AppExtension.html) I think we should retrieve variants from `applicationVariants` property.