### PR TITLE
Fix slow file traversal in configuration phase

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -89,9 +89,9 @@ class GenerationPlugin implements Plugin<Project> {
                 mergeTask.executionData.setFrom(executionData.files + mergeTask.executionData.files)
             }
             if (mergedReportTask != null) {
-                mergedReportTask.classDirectories.setFrom(classDirectories.files + mergedReportTask.classDirectories.files)
-                mergedReportTask.additionalSourceDirs.setFrom(additionalSourceDirs.files + mergedReportTask.additionalSourceDirs.files)
-                mergedReportTask.sourceDirectories.setFrom(sourceDirectories.files + mergedReportTask.sourceDirectories.files)
+                mergedReportTask.classDirectories.setFrom(classDirectories.getFrom() + mergedReportTask.classDirectories.getFrom())
+                mergedReportTask.additionalSourceDirs.setFrom(additionalSourceDirs.getFrom() + mergedReportTask.additionalSourceDirs.getFrom())
+                mergedReportTask.sourceDirectories.setFrom(sourceDirectories.getFrom() + mergedReportTask.sourceDirectories.getFrom())
             }
         }
 
@@ -248,9 +248,9 @@ class GenerationPlugin implements Plugin<Project> {
                 mergeTask.executionData.setFrom(executionData.files + mergeTask.executionData.files)
             }
             if (mergedReportTask != null && addToMergeTask) {
-                mergedReportTask.classDirectories.setFrom(classDirectories.files + mergedReportTask.classDirectories.files)
-                mergedReportTask.additionalSourceDirs.setFrom(additionalSourceDirs.files + mergedReportTask.additionalSourceDirs.files)
-                mergedReportTask.sourceDirectories.setFrom(sourceDirectories.files + mergedReportTask.sourceDirectories.files)
+              mergedReportTask.classDirectories.setFrom(classDirectories.getFrom() + mergedReportTask.classDirectories.getFrom())
+              mergedReportTask.additionalSourceDirs.setFrom(additionalSourceDirs.getFrom() + mergedReportTask.additionalSourceDirs.getFrom())
+              mergedReportTask.sourceDirectories.setFrom(sourceDirectories.getFrom() + mergedReportTask.sourceDirectories.getFrom())
             }
         }
 


### PR DESCRIPTION
Replace `.files` with `.getFrom()` for ConfigurableFileCollection objects
`.files` list all folder content that could be slow for the second build b/c
at that time build folder is not empty.

**Context**: `mergedReportTask.classDirectories += classDirectories` format of adding new files to class directories of Jacoco task was replaced in PR #151 b/c of the [bug in Gradle](https://github.com/gradle/gradle/issues/7636)
with `mergedReportTask.classDirectories.setFrom(classDirectories.files + mergedReportTask.classDirectories.files)` format, that doesn't cause crash but travers the folder and slow down the configuration.
The fix is to replace it with: `mergedReportTask.classDirectories.setFrom(classDirectories.getFrom() + mergedReportTask.classDirectories.getFrom())`

**Disclaimer**: I don't have enough expertise in Gradle to tell if using `getFrom` is the best or even correct solution, but it works on my repo.