### PR TITLE
Add extension options to toggle report formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ junitJacoco {
   excludes // type String List
   includeNoLocationClasses = false // type boolean
   includeInstrumentationCoverageInMergedReport = false // type boolean
+  xml.enabled = true
+  csv.enabled = true
+  html.enabled = true
 }
 ```
 

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -62,9 +62,9 @@ class GenerationPlugin implements Plugin<Project> {
             description = 'Generate Jacoco coverage reports.'
 
             reports {
-                xml.enabled = true
-                csv.enabled = true
-                html.enabled = true
+                xml.enabled = extension.xml.enabled
+                csv.enabled = extension.csv.enabled
+                html.enabled = extension.html.enabled
             }
 
             getClassDirectories().from(subProject.fileTree(
@@ -177,15 +177,15 @@ class GenerationPlugin implements Plugin<Project> {
 
             reports {
                 xml {
-                    enabled = true
+                    enabled = extension.xml.enabled
                     destination subProject.file("$destinationDir/${sourceName}/jacoco.xml")
                 }
                 csv {
-                    enabled = true
+                    enabled = extension.csv.enabled
                     destination subProject.file("$destinationDir/${sourceName}/jacoco.csv")
                 }
                 html {
-                    enabled = true
+                    enabled = extension.html.enabled
                     destination subProject.file("$destinationDir/${sourceName}")
                 }
             }
@@ -299,15 +299,15 @@ class GenerationPlugin implements Plugin<Project> {
 
             reports {
                 xml {
-                    enabled = true
+                    enabled = extension.xml.enabled
                     destination project.file("${project.buildDir}/reports/jacoco/jacoco.xml")
                 }
                 csv {
-                    enabled = true
+                    enabled = extension.csv.enabled
                     destination project.file("${project.buildDir}/reports/jacoco/jacoco.csv")
                 }
                 html {
-                    enabled = true
+                    enabled = extension.html.enabled
                     destination project.file("${project.buildDir}/reports/jacoco")
                 }
             }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -56,4 +56,22 @@ class JunitJacocoExtension {
      * @since 0.13.0
      */
     boolean includeInstrumentationCoverageInMergedReport = false
+
+    /**
+     * Whether or not to generate an xml report
+     * @since 0.17.0
+     */
+    ReportConfig xml = new ReportConfig(true)
+
+    /**
+     * Whether or not to generate a csv report
+     * @since 0.17.0
+     */
+    ReportConfig csv = new ReportConfig(true)
+
+    /**
+     * Whether or not to generate a html report
+     * @since 0.17.0
+     */
+    ReportConfig html = new ReportConfig(true)
 }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/ReportConfig.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/ReportConfig.groovy
@@ -1,0 +1,9 @@
+package com.vanniktech.android.junit.jacoco
+
+class ReportConfig {
+  boolean enabled
+
+  ReportConfig(boolean enabled) {
+    this.enabled = enabled
+  }
+}

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
@@ -11,5 +11,8 @@ class JunitJacocoExtensionTest {
     assert extension.excludes != null
     assert !extension.includeNoLocationClasses
     assert !extension.includeInstrumentationCoverageInMergedReport
+    assert extension.xml.enabled
+    assert extension.csv.enabled
+    assert extension.html.enabled
   }
 }


### PR DESCRIPTION
This exposes a report format option to the extension class, so that users can enable/disable certain format.

```groovy
junitJacoco {
  jacocoVersion = '0.8.2' // type String
  ignoreProjects = [] // type String array
  excludes // type String List
  includeNoLocationClasses = false // type boolean
  includeInstrumentationCoverageInMergedReport = false // type boolean
  xml.enabled = true
  csv.enabled = true
  html.enabled = true
}
```
