### PR TITLE
Kotlin Multiplatform/JVM Without Android

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -40,7 +40,7 @@ class GenerationPlugin implements Plugin<Project> {
         if (!shouldIgnore(subProject, extension)) {
             if (isAndroidProject(subProject)) {
                 return addJacocoAndroid(subProject, extension, mergeTask, mergedReportTask)
-            } else if (isJavaProject(subProject)) {
+            } else if (isJavaProject(subProject) || isKotlinMultiplatform(subProject)) {
                 return addJacocoJava(subProject, extension, mergeTask, mergedReportTask)
             }
         }
@@ -83,7 +83,11 @@ class GenerationPlugin implements Plugin<Project> {
 
             getAdditionalSourceDirs().from(subProject.files(coverageSourceDirs))
             getSourceDirectories().from(subProject.files(coverageSourceDirs))
-            getExecutionData().from(subProject.files(subProject.files("${subProject.buildDir}/jacoco/test.exec")))
+            if(isKotlinMultiplatform(subProject)){
+                getExecutionData().from(subProject.files(subProject.files("${subProject.buildDir}/jacoco/jvmTest.exec")))
+            }else{
+                getExecutionData().from(subProject.files(subProject.files("${subProject.buildDir}/jacoco/test.exec")))
+            }
 
             if (mergeTask != null) {
                 mergeTask.executionData.setFrom(executionData.files + mergeTask.executionData.files)

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -83,9 +83,9 @@ class GenerationPlugin implements Plugin<Project> {
 
             getAdditionalSourceDirs().from(subProject.files(coverageSourceDirs))
             getSourceDirectories().from(subProject.files(coverageSourceDirs))
-            if(isKotlinMultiplatform(subProject)){
+            if (isKotlinMultiplatform(subProject)) {
                 getExecutionData().from(subProject.files(subProject.files("${subProject.buildDir}/jacoco/jvmTest.exec")))
-            }else{
+            } else {
                 getExecutionData().from(subProject.files(subProject.files("${subProject.buildDir}/jacoco/test.exec")))
             }
 


### PR DESCRIPTION
The plugin is not able to discover the jacoco exec file for a potential KMP sub-module targeting jvm, but not android.
In that case `jvmTest.exec` needs to be picked up instead of `test.exec`.

Not sure if this is the right way to fix it.