### PR TITLE
Kotlin Build Scripts: Property shouldn't be immutable

### DIFF
--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -15,7 +15,7 @@ class JunitJacocoExtension {
      * subprojects that should be ignored
      * @since 0.3.0
      */
-    String[] ignoreProjects = []
+    List<String> ignoreProjects = []
 
     /**
      * Patterns of files that should be ignored


### PR DESCRIPTION
Apparently when configuring the plugin in kotlin build scripts, one cannot assign `ignoreProjects`:
```
junitJacoco {
    ignoreProjects = arrayOf("ignored-project")
//  ^ Val cannot be reassigned
}
```

Make `ignoreProjects` of type `List<String>`, instead of `String[]`.
I suppose then one could configure it as follows:
```
junitJacoco {
    ignoreProjects = listOf("ignored-project")
}
```