### PR TITLE
Update to jacoco version 0.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Those are all available configurations - shown with default values and their typ
 
 ```groovy
 junitJacoco {
-  jacocoVersion = '0.8.3' // type String
+  jacocoVersion = '0.8.7' // type String
   ignoreProjects = [] // type String array
   excludes // type String List
   includeNoLocationClasses = false // type boolean

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtension.groovy
@@ -9,7 +9,7 @@ class JunitJacocoExtension {
      * define the version of jacoco which should be used
      * @since 0.3.0
      */
-    String jacocoVersion = '0.8.3'
+    String jacocoVersion = '0.8.7'
 
     /**
      * subprojects that should be ignored

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/GenerationTest.groovy
@@ -254,7 +254,7 @@ class GenerationTest {
     private void assertJacocoAndroidWithFlavors(final Project project) {
         assert project.plugins.hasPlugin(JacocoPlugin)
 
-        assert project.jacoco.toolVersion == '0.8.3'
+        assert project.jacoco.toolVersion == '0.8.7'
 
         assertTask(project, 'red', 'debug')
         assertTask(project, 'red', 'release')
@@ -325,7 +325,7 @@ class GenerationTest {
     private void assertJacocoAndroidWithoutFlavors(final Project project, final boolean hasCoverage) {
         assert project.plugins.hasPlugin(JacocoPlugin)
 
-        assert project.jacoco.toolVersion == '0.8.3'
+        assert project.jacoco.toolVersion == '0.8.7'
 
         final def debugTask = project.tasks.findByName('jacocoTestReportDebug')
 
@@ -536,7 +536,7 @@ class GenerationTest {
     private void assertJacocoJava(final Project project) {
         assert project.plugins.hasPlugin(JacocoPlugin)
 
-        assert project.jacoco.toolVersion == '0.8.3'
+        assert project.jacoco.toolVersion == '0.8.7'
 
         final def task = project.tasks.findByName('jacocoTestReport')
 

--- a/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
+++ b/src/test/groovy/com/vanniktech/android/junit/jacoco/JunitJacocoExtensionTest.groovy
@@ -6,7 +6,7 @@ class JunitJacocoExtensionTest {
   @Test void defaults() {
     def extension = new JunitJacocoExtension()
 
-    assert extension.jacocoVersion == '0.8.3'
+    assert extension.jacocoVersion == '0.8.7'
     assert extension.ignoreProjects.size() == 0
     assert extension.excludes != null
     assert !extension.includeNoLocationClasses


### PR DESCRIPTION
Hello!
I'm looking into using this plugin to get jacoco working with my android project, but I'm having trouble getting Kotlin flows to be recognized in the code coverage report.

I see that many jacoco versions have included changes related to kotlin, and so I'm wondering if a newer version of jacoco would do the trick for me.

In any event, I figure it's a good thing to keep up to date, so I thought I'd open a PR.
The changes here are the same as those in this pr: https://github.com/vanniktech/gradle-android-junit-jacoco-plugin/pull/192