### PR TITLE
Use tasks.withType(Test).configureEach

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ pluginBundle {
   }
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
   testLogging {
     testLogging.exceptionFormat = 'full'
   }

--- a/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
+++ b/src/main/groovy/com/vanniktech/android/junit/jacoco/GenerationPlugin.groovy
@@ -110,7 +110,7 @@ class GenerationPlugin implements Plugin<Project> {
             toolVersion extension.jacocoVersion
         }
 
-        subProject.tasks.withType(Test) {
+        subProject.tasks.withType(Test).configureEach {
             it.jacoco.includeNoLocationClasses = extension.includeNoLocationClasses
         }
 


### PR DESCRIPTION
Replacing `tasks.withType(Test) {}` with `tasks.withType(Test).configureEach`. This fixes an integration issue with Paparazzi screenshot testing library https://github.com/cashapp/paparazzi/issues/410